### PR TITLE
Drop-down menus should not have unique urls. [small fix]

### DIFF
--- a/dormbase/templates/base.html
+++ b/dormbase/templates/base.html
@@ -39,7 +39,7 @@
 	      <li {% block classDirectory %}{% endblock %}><a href="{% url dormbase.core.views.directory %}">Directory</a></li>
 	      <li {% block classPersonal %}{% endblock %}><a href="{% url dormbase.personal.views.profile %}">Personal</a></li>
 	      <li class="dropdown {% block classMediaContent %}{% endblock %}">
-		<a class="dropdown-toggle" data-toggle="dropdown" href="mediaContent">
+		<a class="dropdown-toggle" data-toggle="dropdown" href="">
 		  Media
 		  <b class="caret"></b>
 		</a>
@@ -50,7 +50,7 @@
 		</ul>
 	      </li>
 	      <li class="dropdown {% block classGovernment %}{% endblock %}">
-		<a class="dropdown-toggle" data-toggle="dropdown" href="government">
+		<a class="dropdown-toggle" data-toggle="dropdown" href="">
 		  Government
 		  <b class="caret"></b>
 		</a>
@@ -64,7 +64,7 @@
 		</ul>
 	      </li>
 	      <li class="dropdown {% block classFacilities %}{% endblock %}">
-		<a class="dropdown-toggle" data-toggle="dropdown" href="facilities">
+		<a class="dropdown-toggle" data-toggle="dropdown" href="">
 		  Facilities
 		  <b class="caret"></b>
 		</a>


### PR DESCRIPTION
I noticed while I was exploring the interface, but if you choose to open the media, government, or facilities drop down menus in a new tab/window as if they were meant to be pages, it 404's you. I just took those out.
